### PR TITLE
fixed for issues 3 Can't get tab selection to work

### DIFF
--- a/src/main/java/hu/csekme/RibbonMenu/RibbonBar.java
+++ b/src/main/java/hu/csekme/RibbonMenu/RibbonBar.java
@@ -176,11 +176,11 @@ public class RibbonBar extends JComponent {
 	void toggle() {
 		if (minimized) {
 			setMinimumSize(new Dimension(100, ribbonTabHeight + shadowHeight));
-			setPreferredSize(new Dimension(100, ribbonTabHeight + shadowHeight));
+			setPreferredSize(new Dimension(getWidth(), ribbonTabHeight + shadowHeight));
 			setSize(new Dimension(getWidth(), ribbonTabHeight + shadowHeight));
 		} else {
 			setMinimumSize(new Dimension(0, ribbonHeight));
-			setPreferredSize(new Dimension(100, ribbonHeight));
+			setPreferredSize(new Dimension(getWidth(), ribbonHeight));
 			setSize(new Dimension(getWidth(), ribbonHeight));
 		}
 		getParent().revalidate();
@@ -699,8 +699,8 @@ public class RibbonBar extends JComponent {
 					for (int i = 0; i < TABS.size(); i++) {
 						TABS.get(i).setSelected(TABS.get(i).inBounds(e.getPoint(), TABS.get(i).getToken()));
 					}
-					minimized = false;
-					toggle();
+          minimized = false;
+  			  toggle();
 				}  
 			}
 			if (e.getPoint().y > ribbonTabHeight) {


### PR DESCRIPTION
Fixes for  issues 3 Can't get tab selection to work
and issue 4 After minimize can't get back to original layout
Turned out to simply needed to modify toggle() function to use full width with a getWidth()
instead of hard-coded 100.

Warning!! I think this will wipe out your latest changes  for margins.  Hold off on the pull and I'll fix my end.
